### PR TITLE
[Fix GitHub Actions] - Use @master instead of specific versions to avoid 504 errors.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Copy files to server
-        uses: appleboy/scp-action@v0.1.7
+        uses: appleboy/scp-action@master
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
@@ -24,7 +24,7 @@ jobs:
           target: "~/NezabudkaPetShop"
 
       - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1.0.0
+        uses: appleboy/ssh-action@master
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}


### PR DESCRIPTION
[Fix GitHub Actions] - Use @master instead of specific versions to avoid 504 errors.